### PR TITLE
update git repo link in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/tamino-martinius/node-pg-migrator.git"
+    "url": "https://github.com/tamino-martinius/node-postgres-migrator.git"
   },
   "engines": {
     "node": ">=6.14.0"


### PR DESCRIPTION
hey! this is a solid package; I really appreciate that there are zero dependencies.

I was a bit confused when I saw this package and `node-pg-migrator` on `npm` when searching for a modern migration tool, especially since both NPM pages take you to the `node-pg-migrator` repo. After checking it out, I understand that this repo is where you're putting the latest development?

anyway, I figured that this was why the link was incorrect on the NPM page, thought I'm not sure if this is how NPM resolves those links on their page but seemed like a good shot. I wanted to update it so other can find the repo more easily and contribute! 

thanks